### PR TITLE
feat: configurable default dark mode

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -81,13 +81,21 @@ function samira_theme_scripts() {
     );
     
     // Dark mode script
-    wp_enqueue_script('samira-dark-mode', 
-        SAMIRA_THEME_URI . '/js/dark-mode.js', 
-        array('jquery'), 
-        SAMIRA_THEME_VERSION, 
+    wp_enqueue_script('samira-dark-mode',
+        SAMIRA_THEME_URI . '/js/dark-mode.js',
+        array('jquery'),
+        SAMIRA_THEME_VERSION,
         true
     );
-    
+
+    wp_localize_script(
+        'samira-dark-mode',
+        'samira_dark_mode',
+        array(
+            'default_on' => get_option('samira_enable_dark_mode'),
+        )
+    );
+
     // Localizzazione per AJAX - SINTASSI CORRETTA
     wp_localize_script('samira-main', 'samira_ajax', array(
         'ajax_url' => admin_url('admin-ajax.php'),
@@ -260,7 +268,7 @@ function samira_body_classes($classes) {
     
     // Aggiungi classe per dark mode (se abilitato di default)
     if (get_option('samira_enable_dark_mode', false)) {
-        $classes[] = 'dark-mode-enabled';
+        $classes[] = 'dark-mode';
     }
     
     return $classes;

--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -25,7 +25,8 @@
         // Check for saved preference or system preference
         const savedMode = localStorage.getItem('samira-dark-mode');
         const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const shouldBeDark = savedMode ? savedMode === 'true' : systemPrefersDark;
+        const defaultOn = typeof samira_dark_mode !== 'undefined' && Boolean(Number(samira_dark_mode.default_on));
+        const shouldBeDark = savedMode ? savedMode === 'true' : (defaultOn ? true : systemPrefersDark);
 
         // Apply initial mode
         if (shouldBeDark) {


### PR DESCRIPTION
## Summary
- Rename body class for dark mode to `dark-mode`
- Allow theme option to set default dark mode via localized script flag
- Use localized flag when initializing dark mode script

## Testing
- `php -l functions.php`
- `node --check js/dark-mode.js`


------
https://chatgpt.com/codex/tasks/task_e_6894cc69aeec83339cf764d7d295115c