### PR TITLE
chore(i18n): add translation support

### DIFF
--- a/languages/samira-theme.pot
+++ b/languages/samira-theme.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-07T17:59:23+00:00\n"
+"POT-Creation-Date: 2025-08-07T18:25:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: samira-theme\n"
@@ -55,6 +55,7 @@ msgstr ""
 
 #: admin/theme-admin.php:48
 #: admin/theme-admin.php:49
+#: admin/theme-admin.php:852
 msgid "Statistics"
 msgstr ""
 
@@ -129,7 +130,7 @@ msgid "View Statistics"
 msgstr ""
 
 #: admin/theme-admin.php:158
-#: functions.php:168
+#: functions.php:171
 msgid "Reset to Default Settings"
 msgstr ""
 
@@ -351,14 +352,17 @@ msgid "Newsletter Statistics"
 msgstr ""
 
 #: admin/theme-admin.php:721
+#: admin/theme-admin.php:887
 msgid "Total attempts"
 msgstr ""
 
 #: admin/theme-admin.php:725
+#: admin/theme-admin.php:891
 msgid "Successful subscriptions"
 msgstr ""
 
 #: admin/theme-admin.php:729
+#: admin/theme-admin.php:895
 msgid "Success rate"
 msgstr ""
 
@@ -368,6 +372,71 @@ msgstr ""
 
 #: admin/theme-admin.php:758
 msgid "Save Newsletter Configuration"
+msgstr ""
+
+#: admin/theme-admin.php:844
+msgid "Newsletter logs cleared."
+msgstr ""
+
+#: admin/theme-admin.php:857
+msgid "Site Overview"
+msgstr ""
+
+#: admin/theme-admin.php:861
+msgid "Posts"
+msgstr ""
+
+#: admin/theme-admin.php:865
+msgid "Portfolio Items"
+msgstr ""
+
+#: admin/theme-admin.php:869
+#: functions.php:238
+msgid "Books"
+msgstr ""
+
+#: admin/theme-admin.php:873
+msgid "Social Links"
+msgstr ""
+
+#: admin/theme-admin.php:877
+msgid "Customization"
+msgstr ""
+
+#: admin/theme-admin.php:883
+msgid "Newsletter Activity"
+msgstr ""
+
+#: admin/theme-admin.php:900
+msgid "Recent Activity"
+msgstr ""
+
+#: admin/theme-admin.php:904
+msgid "Email"
+msgstr ""
+
+#: admin/theme-admin.php:905
+msgid "Status"
+msgstr ""
+
+#: admin/theme-admin.php:906
+msgid "Date"
+msgstr ""
+
+#: admin/theme-admin.php:913
+msgid "Success"
+msgstr ""
+
+#: admin/theme-admin.php:913
+msgid "Failed"
+msgstr ""
+
+#: admin/theme-admin.php:920
+msgid "No recent activity."
+msgstr ""
+
+#: admin/theme-admin.php:925
+msgid "Clear Logs"
 msgstr ""
 
 #: footer.php:26
@@ -417,205 +486,201 @@ msgstr ""
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: functions.php:45
+#: functions.php:48
 msgid "Menu Principale"
 msgstr ""
 
-#: functions.php:46
+#: functions.php:49
 msgid "Menu Footer"
 msgstr ""
 
-#: functions.php:97
+#: functions.php:100
 msgid "Light mode activated"
 msgstr ""
 
-#: functions.php:98
+#: functions.php:101
 msgid "Dark mode activated"
 msgstr ""
 
-#: functions.php:99
+#: functions.php:102
 msgid "Activate light mode"
 msgstr ""
 
-#: functions.php:100
+#: functions.php:103
 msgid "Activate dark mode"
 msgstr ""
 
-#: functions.php:110
+#: functions.php:113
 msgid "Loading..."
 msgstr ""
 
-#: functions.php:111
+#: functions.php:114
 msgid "Operation completed!"
 msgstr ""
 
-#: functions.php:112
+#: functions.php:115
 msgid "Error during the operation"
 msgstr ""
 
-#: functions.php:113
-#: functions.php:156
+#: functions.php:116
+#: functions.php:159
 msgid "Required field"
 msgstr ""
 
-#: functions.php:114
-#: functions.php:157
+#: functions.php:117
+#: functions.php:160
 msgid "Invalid email"
 msgstr ""
 
-#: functions.php:115
+#: functions.php:118
 msgid "Name"
 msgstr ""
 
-#: functions.php:116
+#: functions.php:119
 msgid "Scroll to top"
 msgstr ""
 
-#: functions.php:152
+#: functions.php:155
 msgid "Select Image"
 msgstr ""
 
-#: functions.php:153
+#: functions.php:156
 msgid "Use this image"
 msgstr ""
 
-#: functions.php:154
+#: functions.php:157
 msgid "Image uploaded successfully!"
 msgstr ""
 
-#: functions.php:155
+#: functions.php:158
 msgid "Image removed"
 msgstr ""
 
-#: functions.php:158
+#: functions.php:161
 msgid "Invalid URL"
 msgstr ""
 
-#: functions.php:159
+#: functions.php:162
 msgid "Please correct the errors in the form before saving"
 msgstr ""
 
-#: functions.php:160
+#: functions.php:163
 msgid "Saving..."
 msgstr ""
 
-#: functions.php:161
+#: functions.php:164
 msgid "Unsaved changes"
 msgstr ""
 
-#: functions.php:162
+#: functions.php:165
 msgid "Draft saved automatically"
 msgstr ""
 
-#: functions.php:163
+#: functions.php:166
 msgid "Are you sure you want to reset all settings to default? This action cannot be undone."
 msgstr ""
 
-#: functions.php:164
+#: functions.php:167
 msgid "Resetting..."
 msgstr ""
 
-#: functions.php:165
+#: functions.php:168
 msgid "Settings reset successfully!"
 msgstr ""
 
-#: functions.php:166
+#: functions.php:169
 msgid "Error while resetting settings."
 msgstr ""
 
-#: functions.php:167
+#: functions.php:170
 msgid "Connection error during reset."
 msgstr ""
 
-#: functions.php:169
+#: functions.php:172
 msgid "Welcome to the Samira Theme control panel! Start customizing your settings."
 msgstr ""
 
-#: functions.php:181
+#: functions.php:184
 msgid "Footer Widget Area"
 msgstr ""
 
-#: functions.php:183
+#: functions.php:186
 msgid "Widget area in the footer"
 msgstr ""
 
-#: functions.php:191
+#: functions.php:194
 msgid "Blog Sidebar"
 msgstr ""
 
-#: functions.php:193
+#: functions.php:196
 msgid "Sidebar for blog posts"
 msgstr ""
 
-#: functions.php:209
-#: functions.php:211
+#: functions.php:212
+#: functions.php:214
 msgid "Portfolio"
 msgstr ""
 
-#: functions.php:210
+#: functions.php:213
 msgid "Work"
 msgstr ""
 
-#: functions.php:212
+#: functions.php:215
 msgid "Add Work"
 msgstr ""
 
-#: functions.php:213
+#: functions.php:216
 msgid "Add New Work"
 msgstr ""
 
-#: functions.php:214
+#: functions.php:217
 msgid "Edit Work"
 msgstr ""
 
-#: functions.php:215
+#: functions.php:218
 msgid "New Work"
 msgstr ""
 
-#: functions.php:216
+#: functions.php:219
 msgid "View Work"
 msgstr ""
 
-#: functions.php:217
+#: functions.php:220
 msgid "Search Works"
 msgstr ""
 
-#: functions.php:218
+#: functions.php:221
 msgid "No works found"
 msgstr ""
 
-#: functions.php:219
+#: functions.php:222
 msgid "No works in trash"
 msgstr ""
 
-#: functions.php:235
-msgid "Books"
-msgstr ""
-
-#: functions.php:236
+#: functions.php:239
 #: index.php:91
 #: index.php:127
 msgid "Book"
 msgstr ""
 
-#: functions.php:237
+#: functions.php:240
 #: index.php:71
 msgid "My Books"
 msgstr ""
 
-#: functions.php:238
+#: functions.php:241
 msgid "Add Book"
 msgstr ""
 
-#: functions.php:239
+#: functions.php:242
 msgid "Add New Book"
 msgstr ""
 
-#: functions.php:240
+#: functions.php:243
 msgid "Edit Book"
 msgstr ""
 
-#: functions.php:383
+#: functions.php:386
 msgid "You do not have permission to upload SVG files."
 msgstr ""
 


### PR DESCRIPTION
## Summary
- Regenerate POT file with all theme strings
- Ensure theme textdomain is loaded and translation functions are used for WPML compatibility

## Testing
- `php -l functions.php`
- `php wp-cli.phar --allow-root i18n make-pot . languages/samira-theme.pot`


------
https://chatgpt.com/codex/tasks/task_e_6894ee2a7c388333af5a97e4d61012ab