### PR TITLE
feat: add import/export settings page

### DIFF
--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -172,6 +172,20 @@ function samira_validate_option($value, $option_name) {
 }
 
 /**
+ * Export theme options
+ */
+function samira_export_options() {
+    $defaults = samira_get_default_options();
+    $options  = array();
+
+    foreach ($defaults as $option_name => $default_value) {
+        $options[$option_name] = get_option($option_name, $default_value);
+    }
+
+    return $options;
+}
+
+/**
  * Import theme options
  */
 function samira_import_options($options) {


### PR DESCRIPTION
## Summary
- add export utility for theme options
- create admin import/export page with JSON download and upload

## Testing
- `php -l inc/theme-options.php`
- `php -l admin/theme-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_6894f1eff3b8833386fdc62fec0a4a19