### PR TITLE
fix(newsletter): internationalize admin error messages

### DIFF
--- a/admin/theme-admin.php
+++ b/admin/theme-admin.php
@@ -815,7 +815,10 @@ function samira_newsletter_page() {
                     html += '</ul>';
                     $('#available-lists').html(html);
                 } else {
-                    $('#available-lists').html('No lists found or connection error');
+                    var errorMessage = response.data && response.data.message
+                        ? response.data.message
+                        : '<?php echo esc_js( __( 'No lists found or connection error', 'samira-theme' ) ); ?>';
+                    $('#available-lists').html(errorMessage);
                 }
             });
         });

--- a/inc/newsletter-integration.php
+++ b/inc/newsletter-integration.php
@@ -431,7 +431,7 @@ function samira_clear_newsletter_logs() {
  */
 function samira_test_newsletter_ajax() {
     if (!wp_verify_nonce($_POST['nonce'], 'samira_nonce') || !current_user_can('manage_options')) {
-        wp_send_json_error(array('message' => 'Accesso negato'));
+        wp_send_json_error(array('message' => __( 'Access denied', 'samira-theme' )));
     }
     
     $provider = sanitize_text_field($_POST['provider'] ?? '');
@@ -453,7 +453,7 @@ add_action('wp_ajax_samira_test_newsletter', 'samira_test_newsletter_ajax');
  */
 function samira_get_newsletter_lists_ajax() {
     if (!wp_verify_nonce($_POST['nonce'], 'samira_nonce') || !current_user_can('manage_options')) {
-        wp_send_json_error(array('message' => 'Accesso negato'));
+        wp_send_json_error(array('message' => __( 'Access denied', 'samira-theme' )));
     }
     
     $provider = sanitize_text_field($_POST['provider'] ?? '');


### PR DESCRIPTION
## Summary
- replace hardcoded Italian AJAX errors with translatable English strings
- surface translated error messages in newsletter list loader

## Testing
- `php -l inc/newsletter-integration.php`
- `php -l admin/theme-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68950782d7a08333a6b9906e83b4d1c7