### PR TITLE
feat(dark-mode): sync default option with client fallback

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -299,7 +299,7 @@ function samira_body_classes($classes) {
     }
     
     // Aggiungi classe per dark mode (se abilitato di default)
-    if (get_option('samira_enable_dark_mode', false)) {
+    if (boolval(samira_get_option('samira_enable_dark_mode', false))) {
         $classes[] = 'dark-mode';
     }
     

--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -26,7 +26,7 @@
         const savedMode = localStorage.getItem('samira-dark-mode');
         const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const defaultOn = typeof samira_dark_mode !== 'undefined' && Boolean(Number(samira_dark_mode.default_on));
-        const shouldBeDark = savedMode ? savedMode === 'true' : (defaultOn ? true : systemPrefersDark);
+        const shouldBeDark = savedMode === null ? (defaultOn || systemPrefersDark) : savedMode === 'true';
 
         // Apply initial mode
         if (shouldBeDark) {


### PR DESCRIPTION
## Summary
- add `dark-mode` class on body when default option is enabled
- localize default dark mode state and fall back when no user preference exists

## Testing
- `php -l functions.php`
- `node --check js/dark-mode.js`
- `npx eslint js/dark-mode.js` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6895402483288333a0b409a4ae8fc2c5