### PR TITLE
refactor(i18n): translate strings and wrap defaults

### DIFF
--- a/admin/theme-admin.php
+++ b/admin/theme-admin.php
@@ -204,7 +204,7 @@ function samira_render_general_tab() {
                 </th>
                 <td>
                     <input type="text" id="samira_logo_text" name="samira_logo_text" 
-                           value="<?php echo esc_attr(get_option('samira_logo_text', 'SM')); ?>" 
+                           value="<?php echo esc_attr(get_option('samira_logo_text', __( 'SM', 'samira-theme' ))); ?>"
                            class="regular-text" />
                     <p class="description"><?php _e('Logo text if you don\'t upload a custom logo', 'samira-theme'); ?></p>
                 </td>
@@ -216,7 +216,7 @@ function samira_render_general_tab() {
                 </th>
                 <td>
                     <input type="text" id="samira_copyright_name" name="samira_copyright_name" 
-                           value="<?php echo esc_attr(get_option('samira_copyright_name', 'Samira Mahmoodi')); ?>" 
+                           value="<?php echo esc_attr(get_option('samira_copyright_name', __( 'Samira Mahmoodi', 'samira-theme' ))); ?>"
                            class="regular-text" />
                 </td>
             </tr>
@@ -226,7 +226,7 @@ function samira_render_general_tab() {
                     <label for="samira_footer_text"><?php _e('Footer Text', 'samira-theme'); ?></label>
                 </th>
                 <td>
-                    <textarea id="samira_footer_text" name="samira_footer_text" rows="3" class="large-text"><?php echo esc_textarea(get_option('samira_footer_text', 'Writer and artist. Art is my safe haven for self-expression.')); ?></textarea>
+                    <textarea id="samira_footer_text" name="samira_footer_text" rows="3" class="large-text"><?php echo esc_textarea(get_option('samira_footer_text', __( 'Writer and artist. Art is my safe haven for self-expression.', 'samira-theme' ))); ?></textarea>
                 </td>
             </tr>
 
@@ -296,7 +296,7 @@ function samira_render_hero_tab() {
                 </th>
                 <td>
                     <input type="text" id="samira_hero_title" name="samira_hero_title" 
-                           value="<?php echo esc_attr(get_option('samira_hero_title', 'Samira Mahmoodi')); ?>" 
+                           value="<?php echo esc_attr(get_option('samira_hero_title', __( 'Samira Mahmoodi', 'samira-theme' ))); ?>"
                            class="large-text" />
                 </td>
             </tr>
@@ -307,7 +307,7 @@ function samira_render_hero_tab() {
                 </th>
                 <td>
                     <input type="text" id="samira_hero_subtitle" name="samira_hero_subtitle" 
-                           value="<?php echo esc_attr(get_option('samira_hero_subtitle', 'Writing, Art, Rebirth')); ?>" 
+                           value="<?php echo esc_attr(get_option('samira_hero_subtitle', __( 'Writing, Art, Rebirth', 'samira-theme' ))); ?>"
                            class="large-text" />
                 </td>
             </tr>
@@ -355,7 +355,7 @@ function samira_render_about_tab() {
                 </th>
                 <td>
                     <input type="text" id="samira_about_title" name="samira_about_title" 
-                           value="<?php echo esc_attr(get_option('samira_about_title', 'About Me')); ?>" 
+                           value="<?php echo esc_attr(get_option('samira_about_title', __( 'About Me', 'samira-theme' ))); ?>"
                            class="large-text" />
                 </td>
             </tr>
@@ -366,7 +366,7 @@ function samira_render_about_tab() {
                 </th>
                 <td>
                     <?php
-                    $about_content = get_option('samira_about_content', 'Samira Mahmoodi began writing shortly after graduating from college...');
+                    $about_content = get_option('samira_about_content', __( 'Samira Mahmoodi began writing shortly after graduating from college...', 'samira-theme' ));
                     wp_editor($about_content, 'samira_about_content', array(
                         'textarea_rows' => 10,
                         'media_buttons' => false,
@@ -401,7 +401,7 @@ function samira_render_writing_tab() {
                 </th>
                 <td>
                     <input type="text" id="samira_book_title" name="samira_book_title" 
-                           value="<?php echo esc_attr(get_option('samira_book_title', 'To Water Her Garden: A journey of self-discovery')); ?>" 
+                           value="<?php echo esc_attr(get_option('samira_book_title', __( 'To Water Her Garden: A journey of self-discovery', 'samira-theme' ))); ?>"
                            class="large-text" />
                 </td>
             </tr>
@@ -412,7 +412,7 @@ function samira_render_writing_tab() {
                 </th>
                 <td>
                     <input type="text" id="samira_book_year" name="samira_book_year" 
-                           value="<?php echo esc_attr(get_option('samira_book_year', '2019')); ?>" 
+                           value="<?php echo esc_attr(get_option('samira_book_year', __( '2019', 'samira-theme' ))); ?>"
                            class="regular-text" />
                 </td>
             </tr>
@@ -422,7 +422,7 @@ function samira_render_writing_tab() {
                     <label for="samira_book_description"><?php _e('Book Description', 'samira-theme'); ?></label>
                 </th>
                 <td>
-                    <textarea id="samira_book_description" name="samira_book_description" rows="4" class="large-text"><?php echo esc_textarea(get_option('samira_book_description', 'In this space I unveiled the reasons behind my sadness...')); ?></textarea>
+                    <textarea id="samira_book_description" name="samira_book_description" rows="4" class="large-text"><?php echo esc_textarea(get_option('samira_book_description', __( 'In this space I unveiled the reasons behind my sadness...', 'samira-theme' ))); ?></textarea>
                 </td>
             </tr>
 
@@ -691,7 +691,7 @@ function samira_newsletter_page() {
                                 </th>
                                 <td>
                                     <input type="text" id="samira_newsletter_title" name="samira_newsletter_title" 
-                                           value="<?php echo esc_attr(get_option('samira_newsletter_title', 'Stay Connected')); ?>" 
+                                           value="<?php echo esc_attr(get_option('samira_newsletter_title', __( 'Stay Connected', 'samira-theme' ))); ?>"
                                            class="large-text" />
                                 </td>
                             </tr>
@@ -702,7 +702,7 @@ function samira_newsletter_page() {
                                 </th>
                                 <td>
                                     <textarea id="samira_newsletter_description" name="samira_newsletter_description" 
-                                              rows="3" class="large-text"><?php echo esc_textarea(get_option('samira_newsletter_description', 'Subscribe to receive my thoughts, updates on current and future releases.')); ?></textarea>
+                                              rows="3" class="large-text"><?php echo esc_textarea(get_option('samira_newsletter_description', __( 'Subscribe to receive my thoughts, updates on current and future releases.', 'samira-theme' ))); ?></textarea>
                                 </td>
                             </tr>
                         </table>

--- a/footer.php
+++ b/footer.php
@@ -9,13 +9,13 @@
                         <?php the_custom_logo(); ?>
                     <?php else: ?>
                         <a href="<?php echo esc_url(home_url('/')); ?>" class="footer-logo" rel="home">
-                            <?php echo esc_html(get_option('samira_logo_text', 'SM')); ?>
+                            <?php echo esc_html(get_option('samira_logo_text', __( 'SM', 'samira-theme' ))); ?>
                         </a>
                     <?php endif; ?>
                     
                     <p class="footer-bio">
                         <?php 
-                        $footer_text = get_option('samira_footer_text', 'Writer and artist. Art is my safe haven for self-expression.');
+                        $footer_text = get_option('samira_footer_text', __( 'Writer and artist. Art is my safe haven for self-expression.', 'samira-theme' ));
                         echo esc_html($footer_text);
                         ?>
                     </p>
@@ -77,13 +77,13 @@
                 <div class="footer-newsletter">
                     <h4 class="footer-section-title">
                         <?php 
-                        $newsletter_title = get_option('samira_newsletter_title', 'Stay Connected');
+                        $newsletter_title = get_option('samira_newsletter_title', __( 'Stay Connected', 'samira-theme' ));
                         echo esc_html($newsletter_title);
                         ?>
                     </h4>
                     <p class="newsletter-description">
                         <?php 
-                        $newsletter_description = get_option('samira_newsletter_description', 'Subscribe to receive my thoughts, updates on current and future releases.');
+                        $newsletter_description = get_option('samira_newsletter_description', __( 'Subscribe to receive my thoughts, updates on current and future releases.', 'samira-theme' ));
                         echo esc_html($newsletter_description);
                         ?>
                     </p>
@@ -123,7 +123,7 @@
                     <p class="footer-copyright">
                         &copy; <?php echo date('Y'); ?> 
                         <?php 
-                        $copyright_name = get_option('samira_copyright_name', 'Samira Mahmoodi');
+                        $copyright_name = get_option('samira_copyright_name', __( 'Samira Mahmoodi', 'samira-theme' ));
                         echo esc_html($copyright_name);
                         ?>. 
                         <?php esc_html_e('All rights reserved.', 'samira-theme'); ?>

--- a/functions.php
+++ b/functions.php
@@ -6,24 +6,24 @@
  * @version 1.0.0
  */
 
-// Impedisce accesso diretto
+// Prevent direct access
 if (!defined('ABSPATH')) {
     exit;
 }
 
-// Costanti del tema
+// Theme constants
 define('SAMIRA_THEME_VERSION', '1.0.0');
 define('SAMIRA_THEME_DIR', get_template_directory());
 define('SAMIRA_THEME_URI', get_template_directory_uri());
 
 /**
- * Setup del tema
+ * Theme setup
  */
 function samira_theme_setup() {
-    // Carica il textdomain del tema
+    // Load theme text domain
     load_theme_textdomain('samira-theme', get_template_directory() . '/languages');
 
-    // Supporto per le caratteristiche del tema
+    // Theme feature support
     add_theme_support('title-tag');
     add_theme_support('post-thumbnails');
     add_theme_support('custom-logo', array(
@@ -43,13 +43,13 @@ function samira_theme_setup() {
     add_theme_support('wp-block-styles');
     add_theme_support('align-wide');
     
-    // Menu di navigazione
+    // Navigation menus
     register_nav_menus(array(
-        'primary' => __('Menu Principale', 'samira-theme'),
-        'footer'  => __('Menu Footer', 'samira-theme'),
+        'primary' => __('Primary Menu', 'samira-theme'),
+        'footer'  => __('Footer Menu', 'samira-theme'),
     ));
     
-    // Formati post
+    // Post formats
     add_theme_support('post-formats', array(
         'aside',
         'image',
@@ -62,10 +62,10 @@ function samira_theme_setup() {
 add_action('after_setup_theme', 'samira_theme_setup');
 
 /**
- * Enqueue degli script e stili
+ * Enqueue scripts and styles
  */
 function samira_theme_scripts() {
-    // CSS principale
+    // Main CSS
     wp_enqueue_style('samira-style', get_stylesheet_uri(), array(), SAMIRA_THEME_VERSION);
     
     // Google Fonts
@@ -75,7 +75,7 @@ function samira_theme_scripts() {
         null
     );
     
-    // JavaScript principale
+    // Main JavaScript
     wp_enqueue_script('samira-main', 
         SAMIRA_THEME_URI . '/js/main.js', 
         array('jquery'), 
@@ -106,7 +106,7 @@ function samira_theme_scripts() {
         )
     );
 
-    // Localizzazione per AJAX
+    // Localization for AJAX
     wp_localize_script('samira-main', 'samira_ajax', array(
         'ajax_url' => admin_url('admin-ajax.php'),
         'nonce'    => wp_create_nonce('samira_nonce'),
@@ -132,7 +132,7 @@ add_action('wp_enqueue_scripts', 'samira_theme_scripts');
  * Enqueue admin scripts
  */
 function samira_admin_scripts($hook) {
-    // Solo nelle pagine del tema
+    // Only on theme pages
     if (strpos($hook, 'samira-theme') !== false) {
         wp_enqueue_style('samira-admin-style', 
             SAMIRA_THEME_URI . '/admin/admin-style.css', 
@@ -146,9 +146,9 @@ function samira_admin_scripts($hook) {
             true
         );
         wp_enqueue_style('wp-color-picker');
-        wp_enqueue_media(); // Per media uploader
+        wp_enqueue_media(); // For media uploader
         
-        // Localizzazione admin
+        // Admin localization
         wp_localize_script('samira-admin-script', 'samira_admin', array(
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce'    => wp_create_nonce('samira_admin_nonce'),
@@ -279,7 +279,7 @@ function samira_include_files() {
 add_action('after_setup_theme', 'samira_include_files', 20);
 
 /**
- * Gestione degli errori JavaScript
+ * JavaScript error handling
  */
 function samira_javascript_detection() {
     echo "<script>(function(html){html.className = html.className.replace(/\\bno-js\\b/,'js')})(document.documentElement);</script>\n";
@@ -287,18 +287,18 @@ function samira_javascript_detection() {
 add_action('wp_head', 'samira_javascript_detection', 0);
 
 /**
- * Aggiungi classe body per tema
+ * Add body class for theme
  */
 function samira_body_classes($classes) {
-    // Aggiungi classe per il tema
+    // Add class for the theme
     $classes[] = 'samira-theme';
-    
-    // Aggiungi classe per homepage personalizzata
+
+    // Add class for custom homepage
     if (is_front_page()) {
         $classes[] = 'samira-homepage';
     }
-    
-    // Aggiungi classe per dark mode (se abilitato di default)
+
+    // Add class for dark mode (if enabled by default)
     if (boolval(samira_get_option('samira_enable_dark_mode', false))) {
         $classes[] = 'dark-mode';
     }
@@ -308,7 +308,7 @@ function samira_body_classes($classes) {
 add_filter('body_class', 'samira_body_classes');
 
 /**
- * Personalizza excerpt length
+ * Customize excerpt length
  */
 function samira_excerpt_length($length) {
     return 25;
@@ -316,7 +316,7 @@ function samira_excerpt_length($length) {
 add_filter('excerpt_length', 'samira_excerpt_length');
 
 /**
- * Personalizza excerpt more
+ * Customize excerpt more
  */
 function samira_excerpt_more($more) {
     return '...';
@@ -324,7 +324,7 @@ function samira_excerpt_more($more) {
 add_filter('excerpt_more', 'samira_excerpt_more');
 
 /**
- * Aggiungi meta tags personalizzati
+ * Add custom meta tags
  */
 function samira_head_meta() {
     echo '<meta name="theme-color" content="#D4A574">' . "\n";
@@ -334,7 +334,7 @@ function samira_head_meta() {
 add_action('wp_head', 'samira_head_meta');
 
 /**
- * Disabilita emoji se non necessari
+ * Disable emojis if not needed
  */
 function samira_disable_emojis() {
     if (get_option('samira_disable_emojis', false)) {
@@ -368,7 +368,7 @@ function samira_disable_emojis_dns_prefetch($urls, $relation_type) {
 }
 
 /**
- * Aggiungi supporto per SVG upload (solo per admin)
+ * Add SVG upload support (admin only)
  */
 function samira_mime_types($mimes) {
     if (current_user_can('manage_options')) {
@@ -379,7 +379,7 @@ function samira_mime_types($mimes) {
 add_filter('upload_mimes', 'samira_mime_types');
 
 /**
- * Sicurezza SVG upload
+ * SVG upload security
  */
 function samira_check_svg($file) {
     if ($file['type'] === 'image/svg+xml') {
@@ -392,7 +392,7 @@ function samira_check_svg($file) {
 add_filter('wp_handle_upload_prefilter', 'samira_check_svg');
 
 /**
- * Pulizia wp_head
+ * Clean up wp_head
  */
 function samira_clean_head() {
     if (get_option('samira_clean_head', true)) {
@@ -441,7 +441,7 @@ function samira_theme_activation() {
 add_action('after_switch_theme', 'samira_theme_activation');
 
 /**
- * Pulizia alla disattivazione del tema
+ * Cleanup on theme deactivation
  */
 function samira_theme_deactivation() {
     // Flush rewrite rules
@@ -450,12 +450,12 @@ function samira_theme_deactivation() {
 add_action('switch_theme', 'samira_theme_deactivation');
 
 /**
- * Aggiungi CSS inline per accent color
+ * Add inline CSS for accent color
  */
 function samira_accent_color_css() {
     $accent_color = get_option('samira_accent_color', '#D4A574');
     
-    // Genera colore hover (più scuro)
+    // Generate hover color (darker)
     $rgb = sscanf($accent_color, "#%02x%02x%02x");
     if ($rgb && count($rgb) === 3) {
         $hover_color = sprintf("#%02x%02x%02x", 
@@ -470,7 +470,7 @@ function samira_accent_color_css() {
 add_action('wp_head', 'samira_accent_color_css', 20);
 
 /**
- * Controlla requisiti tema
+ * Check theme requirements
  */
 function samira_check_requirements() {
     $wp_version = get_bloginfo('version');

--- a/header.php
+++ b/header.php
@@ -33,7 +33,7 @@
 						?>
 						<h1 class="site-title">
 							<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-								<?php echo esc_html( get_option( 'samira_logo_text', 'SM' ) ); ?>
+                                                                <?php echo esc_html( get_option( 'samira_logo_text', __( 'SM', 'samira-theme' ) ) ); ?>
 							</a>
 						</h1>
 						<?php

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -6,7 +6,7 @@
  * @version 1.0.0
  */
 
-// Impedisce accesso diretto
+// Prevent direct access
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -19,13 +19,13 @@ function samira_customize_register($wp_customize) {
     // Quick settings panel (for basic users)
     $wp_customize->add_panel('samira_quick_settings', array(
         'title' => __('Samira Quick Settings', 'samira-theme'),
-        'description' => __('Impostazioni rapide per il tema Samira', 'samira-theme'),
+        'description' => __('Quick settings for the Samira Theme', 'samira-theme'),
         'priority' => 30,
     ));
 
     // Colors section
     $wp_customize->add_section('samira_colors', array(
-        'title' => __('Colori', 'samira-theme'),
+        'title' => __('Colors', 'samira-theme'),
         'panel' => 'samira_quick_settings',
         'priority' => 10,
     ));
@@ -38,24 +38,24 @@ function samira_customize_register($wp_customize) {
     ));
 
     $wp_customize->add_control(new WP_Customize_Color_Control($wp_customize, 'samira_accent_color', array(
-        'label' => __('Colore Accento', 'samira-theme'),
+        'label' => __('Accent Color', 'samira-theme'),
         'section' => 'samira_colors',
     )));
 
     // Typography section (future enhancement)
     $wp_customize->add_section('samira_typography', array(
-        'title' => __('Tipografia', 'samira-theme'),
+        'title' => __('Typography', 'samira-theme'),
         'panel' => 'samira_quick_settings',
         'priority' => 20,
     ));
 
     // Link to full admin panel
     $wp_customize->add_section('samira_admin_link', array(
-        'title' => __('Impostazioni Complete', 'samira-theme'),
+        'title' => __('Full Settings', 'samira-theme'),
         'priority' => 200,
         'description' => sprintf(
-            __('Per impostazioni avanzate, vai al %s', 'samira-theme'),
-            '<a href="' . admin_url('admin.php?page=samira-theme-settings') . '">' . __('Pannello Samira Theme', 'samira-theme') . '</a>'
+            __('For advanced settings, go to %s', 'samira-theme'),
+            '<a href="' . admin_url('admin.php?page=samira-theme-settings') . '">' . __('Samira Theme Panel', 'samira-theme') . '</a>'
         ),
     ));
 }

--- a/inc/newsletter-integration.php
+++ b/inc/newsletter-integration.php
@@ -6,21 +6,21 @@
  * @version 1.0.0
  */
 
-// Impedisce accesso diretto
+// Prevent direct access
 if (!defined('ABSPATH')) {
     exit;
 }
 
 /**
- * Handler AJAX per newsletter signup
+ * AJAX handler for newsletter signup
  */
 function samira_newsletter_signup() {
-    // Verifica nonce per sicurezza
+    // Verify nonce for security
     if (!wp_verify_nonce($_POST['nonce'], 'samira_nonce')) {
         wp_send_json_error(array('message' => __( 'Security error', 'samira-theme' )));
     }
     
-    // Sanitize e validate input
+    // Sanitize and validate input
     $email = sanitize_email($_POST['email'] ?? '');
     $name = sanitize_text_field($_POST['name'] ?? '');
     

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -47,7 +47,7 @@ function samira_get_default_options() {
 
         // Writing Section
         'samira_book_title'       => __( 'To Water Her Garden: A journey of self-discovery', 'samira-theme' ),
-        'samira_book_year'        => '2019',
+        'samira_book_year'        => __( '2019', 'samira-theme' ),
         'samira_book_description' => __(
             'Within this space I revealed the reasons behind my sadness and where I also discovered my greatest power: myself.',
             'samira-theme'
@@ -76,7 +76,7 @@ function samira_get_default_options() {
         'samira_social_facebook'  => '',
 
         // Branding
-        'samira_logo_text'        => 'SM',
+        'samira_logo_text'        => __( 'SM', 'samira-theme' ),
         'samira_accent_color'     => '#D4A574',
         'samira_enable_dark_mode' => false,
 

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template principale
+ * Main template
  * 
  * @package Samira_Theme
  */
@@ -30,7 +30,7 @@ get_header(); ?>
                         <?php 
                         $hero_image = get_option('samira_hero_image');
                         if ($hero_image): ?>
-                            <img src="<?php echo esc_url($hero_image); ?>" alt="<?php echo esc_attr(get_option('samira_hero_title', 'Samira Mahmoodi')); ?>" class="hero__img">
+                            <img src="<?php echo esc_url($hero_image); ?>" alt="<?php echo esc_attr(get_option('samira_hero_title', __( 'Samira Mahmoodi', 'samira-theme' ))); ?>" class="hero__img">
                         <?php else: ?>
                             <div class="hero__img-placeholder">
                                 <svg width="120" height="120" viewBox="0 0 120 120" fill="currentColor">
@@ -71,7 +71,7 @@ get_header(); ?>
                 <h2 class="section__title"><?php echo esc_html__( 'My Books', 'samira-theme' ); ?></h2>
                 <div class="writing__content">
                     <?php
-                    // Prima mostra i libri dal custom post type
+                    // Display books from custom post type first
                     $books_query = new WP_Query(array(
                         'post_type' => 'books',
                         'posts_per_page' => -1,
@@ -115,7 +115,7 @@ get_header(); ?>
                         <?php endwhile;
                         wp_reset_postdata();
                     else:
-                        // Fallback al libro dalle opzioni del tema
+                        // Fallback to book from theme options
                         ?>
                         <div class="book-card">
                             <?php 
@@ -129,9 +129,9 @@ get_header(); ?>
                             <?php endif; ?>
                             <div class="book-card__content">
                                 <h3 class="book-card__title">
-                                    <?php echo esc_html(get_option('samira_book_title', 'To Water Her Garden: A journey of self-discovery')); ?>
+                                    <?php echo esc_html(get_option('samira_book_title', __( 'To Water Her Garden: A journey of self-discovery', 'samira-theme' ))); ?>
                                 </h3>
-                                <p class="book-card__year"><?php echo esc_html(get_option('samira_book_year', '2019')); ?></p>
+                                <p class="book-card__year"><?php echo esc_html(get_option('samira_book_year', __( '2019', 'samira-theme' ))); ?></p>
                                 <p class="book-card__description">
                                       <?php echo esc_html( get_option('samira_book_description', __( 'Within this space I revealed the reasons behind my sadness and where I also discovered my greatest power: myself.', 'samira-theme' )) ); ?>
                                 </p>
@@ -229,7 +229,7 @@ get_header(); ?>
 
     <?php else: ?>
 
-        <!-- Template per altre pagine -->
+        <!-- Template for other pages -->
         <div class="container">
             <div class="content-area">
                 <?php if (have_posts()): ?>

--- a/languages/samira-theme.pot
+++ b/languages/samira-theme.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-07T18:25:24+00:00\n"
+"POT-Creation-Date: 2025-08-08T09:11:37+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: samira-theme\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #. Description of the theme
 #: style.css
-msgid "Tema WordPress moderno e minimal per scrittori e artisti. Include dark mode, newsletter integration, e pannello di controllo personalizzato."
+msgid "Modern and minimal WordPress theme for writers and artists. Includes dark mode, newsletter integration, and a custom control panel."
 msgstr ""
 
 #. Author of the theme
@@ -55,7 +55,7 @@ msgstr ""
 
 #: admin/theme-admin.php:48
 #: admin/theme-admin.php:49
-#: admin/theme-admin.php:852
+#: admin/theme-admin.php:855
 msgid "Statistics"
 msgstr ""
 
@@ -82,13 +82,14 @@ msgid "Hero Section"
 msgstr ""
 
 #: admin/theme-admin.php:90
+#: admin/theme-admin.php:358
 #: inc/theme-options.php:42
 #: index.php:49
 msgid "About Me"
 msgstr ""
 
 #: admin/theme-admin.php:93
-#: header.php:88
+#: header.php:86
 msgid "Writing"
 msgstr ""
 
@@ -130,7 +131,7 @@ msgid "View Statistics"
 msgstr ""
 
 #: admin/theme-admin.php:158
-#: functions.php:171
+#: functions.php:172
 msgid "Reset to Default Settings"
 msgstr ""
 
@@ -142,6 +143,13 @@ msgstr ""
 msgid "Logo Text"
 msgstr ""
 
+#: admin/theme-admin.php:207
+#: footer.php:12
+#: header.php:36
+#: inc/theme-options.php:79
+msgid "SM"
+msgstr ""
+
 #: admin/theme-admin.php:209
 msgid "Logo text if you don't upload a custom logo"
 msgstr ""
@@ -150,8 +158,24 @@ msgstr ""
 msgid "Copyright Name"
 msgstr ""
 
+#: admin/theme-admin.php:219
+#: admin/theme-admin.php:299
+#: footer.php:126
+#: inc/theme-options.php:37
+#: inc/theme-options.php:85
+#: index.php:19
+#: index.php:33
+msgid "Samira Mahmoodi"
+msgstr ""
+
 #: admin/theme-admin.php:226
 msgid "Footer Text"
+msgstr ""
+
+#: admin/theme-admin.php:229
+#: footer.php:18
+#: inc/theme-options.php:84
+msgid "Writer and artist. Art is my safe haven for self-expression."
 msgstr ""
 
 #: admin/theme-admin.php:235
@@ -194,6 +218,12 @@ msgstr ""
 msgid "Subtitle"
 msgstr ""
 
+#: admin/theme-admin.php:310
+#: inc/theme-options.php:38
+#: index.php:22
+msgid "Writing, Art, Rebirth"
+msgstr ""
+
 #: admin/theme-admin.php:317
 msgid "Hero Image"
 msgstr ""
@@ -223,6 +253,10 @@ msgstr ""
 msgid "About Content"
 msgstr ""
 
+#: admin/theme-admin.php:369
+msgid "Samira Mahmoodi began writing shortly after graduating from college..."
+msgstr ""
+
 #: admin/theme-admin.php:376
 msgid "Write your biography and personal story"
 msgstr ""
@@ -243,12 +277,28 @@ msgstr ""
 msgid "Main Book Title"
 msgstr ""
 
+#: admin/theme-admin.php:404
+#: inc/theme-options.php:49
+#: index.php:132
+msgid "To Water Her Garden: A journey of self-discovery"
+msgstr ""
+
 #: admin/theme-admin.php:411
 msgid "Publication Year"
 msgstr ""
 
+#: admin/theme-admin.php:415
+#: inc/theme-options.php:50
+#: index.php:134
+msgid "2019"
+msgstr ""
+
 #: admin/theme-admin.php:422
 msgid "Book Description"
+msgstr ""
+
+#: admin/theme-admin.php:425
+msgid "In this space I unveiled the reasons behind my sadness..."
 msgstr ""
 
 #: admin/theme-admin.php:431
@@ -272,6 +322,7 @@ msgid "Style Customization"
 msgstr ""
 
 #: admin/theme-admin.php:541
+#: inc/customizer.php:41
 msgid "Accent Color"
 msgstr ""
 
@@ -343,8 +394,22 @@ msgstr ""
 msgid "Newsletter Text"
 msgstr ""
 
+#: admin/theme-admin.php:694
+#: footer.php:80
+#: inc/theme-options.php:65
+#: index.php:205
+msgid "Stay Connected"
+msgstr ""
+
 #: admin/theme-admin.php:701
 msgid "Description"
+msgstr ""
+
+#: admin/theme-admin.php:705
+#: footer.php:86
+#: inc/theme-options.php:66
+#: index.php:207
+msgid "Subscribe to receive my thoughts, updates on current and future releases."
 msgstr ""
 
 #: admin/theme-admin.php:714
@@ -352,17 +417,17 @@ msgid "Newsletter Statistics"
 msgstr ""
 
 #: admin/theme-admin.php:721
-#: admin/theme-admin.php:887
+#: admin/theme-admin.php:890
 msgid "Total attempts"
 msgstr ""
 
 #: admin/theme-admin.php:725
-#: admin/theme-admin.php:891
+#: admin/theme-admin.php:894
 msgid "Successful subscriptions"
 msgstr ""
 
 #: admin/theme-admin.php:729
-#: admin/theme-admin.php:895
+#: admin/theme-admin.php:898
 msgid "Success rate"
 msgstr ""
 
@@ -374,69 +439,106 @@ msgstr ""
 msgid "Save Newsletter Configuration"
 msgstr ""
 
-#: admin/theme-admin.php:844
+#: admin/theme-admin.php:820
+msgid "No lists found or connection error"
+msgstr ""
+
+#: admin/theme-admin.php:847
 msgid "Newsletter logs cleared."
 msgstr ""
 
-#: admin/theme-admin.php:857
+#: admin/theme-admin.php:860
 msgid "Site Overview"
 msgstr ""
 
-#: admin/theme-admin.php:861
+#: admin/theme-admin.php:864
 msgid "Posts"
 msgstr ""
 
-#: admin/theme-admin.php:865
+#: admin/theme-admin.php:868
 msgid "Portfolio Items"
 msgstr ""
 
-#: admin/theme-admin.php:869
-#: functions.php:238
+#: admin/theme-admin.php:872
+#: functions.php:239
 msgid "Books"
 msgstr ""
 
-#: admin/theme-admin.php:873
+#: admin/theme-admin.php:876
 msgid "Social Links"
 msgstr ""
 
-#: admin/theme-admin.php:877
+#: admin/theme-admin.php:880
 msgid "Customization"
 msgstr ""
 
-#: admin/theme-admin.php:883
+#: admin/theme-admin.php:886
 msgid "Newsletter Activity"
 msgstr ""
 
-#: admin/theme-admin.php:900
+#: admin/theme-admin.php:903
 msgid "Recent Activity"
 msgstr ""
 
-#: admin/theme-admin.php:904
+#: admin/theme-admin.php:907
 msgid "Email"
 msgstr ""
 
-#: admin/theme-admin.php:905
+#: admin/theme-admin.php:908
 msgid "Status"
 msgstr ""
 
-#: admin/theme-admin.php:906
+#: admin/theme-admin.php:909
 msgid "Date"
 msgstr ""
 
-#: admin/theme-admin.php:913
+#: admin/theme-admin.php:916
 msgid "Success"
 msgstr ""
 
-#: admin/theme-admin.php:913
+#: admin/theme-admin.php:916
 msgid "Failed"
 msgstr ""
 
-#: admin/theme-admin.php:920
+#: admin/theme-admin.php:923
 msgid "No recent activity."
 msgstr ""
 
-#: admin/theme-admin.php:925
+#: admin/theme-admin.php:928
 msgid "Clear Logs"
+msgstr ""
+
+#: admin/theme-admin.php:966
+msgid "Settings imported successfully."
+msgstr ""
+
+#: admin/theme-admin.php:971
+msgid "Invalid JSON file."
+msgstr ""
+
+#: admin/theme-admin.php:974
+msgid "Please upload a JSON file."
+msgstr ""
+
+#: admin/theme-admin.php:980
+msgid "Import/Export Settings"
+msgstr ""
+
+#: admin/theme-admin.php:985
+msgid "Export Settings"
+msgstr ""
+
+#: admin/theme-admin.php:988
+msgid "Download your current theme settings as a JSON file."
+msgstr ""
+
+#: admin/theme-admin.php:989
+msgid "Download Settings"
+msgstr ""
+
+#: admin/theme-admin.php:994
+#: admin/theme-admin.php:998
+msgid "Import Settings"
 msgstr ""
 
 #: footer.php:26
@@ -487,200 +589,200 @@ msgid "Something went wrong. Please try again."
 msgstr ""
 
 #: functions.php:48
-msgid "Menu Principale"
+msgid "Primary Menu"
 msgstr ""
 
 #: functions.php:49
-msgid "Menu Footer"
-msgstr ""
-
-#: functions.php:100
-msgid "Light mode activated"
+msgid "Footer Menu"
 msgstr ""
 
 #: functions.php:101
-msgid "Dark mode activated"
+msgid "Light mode activated"
 msgstr ""
 
 #: functions.php:102
-msgid "Activate light mode"
+msgid "Dark mode activated"
 msgstr ""
 
 #: functions.php:103
+msgid "Activate light mode"
+msgstr ""
+
+#: functions.php:104
 msgid "Activate dark mode"
 msgstr ""
 
-#: functions.php:113
+#: functions.php:114
 msgid "Loading..."
 msgstr ""
 
-#: functions.php:114
+#: functions.php:115
 msgid "Operation completed!"
 msgstr ""
 
-#: functions.php:115
-msgid "Error during the operation"
-msgstr ""
-
 #: functions.php:116
-#: functions.php:159
-msgid "Required field"
+msgid "Error during the operation"
 msgstr ""
 
 #: functions.php:117
 #: functions.php:160
-msgid "Invalid email"
+msgid "Required field"
 msgstr ""
 
 #: functions.php:118
-msgid "Name"
+#: functions.php:161
+msgid "Invalid email"
 msgstr ""
 
 #: functions.php:119
+msgid "Name"
+msgstr ""
+
+#: functions.php:120
 msgid "Scroll to top"
 msgstr ""
 
-#: functions.php:155
+#: functions.php:156
 msgid "Select Image"
 msgstr ""
 
-#: functions.php:156
+#: functions.php:157
 msgid "Use this image"
 msgstr ""
 
-#: functions.php:157
+#: functions.php:158
 msgid "Image uploaded successfully!"
 msgstr ""
 
-#: functions.php:158
+#: functions.php:159
 msgid "Image removed"
 msgstr ""
 
-#: functions.php:161
+#: functions.php:162
 msgid "Invalid URL"
 msgstr ""
 
-#: functions.php:162
+#: functions.php:163
 msgid "Please correct the errors in the form before saving"
 msgstr ""
 
-#: functions.php:163
+#: functions.php:164
 msgid "Saving..."
 msgstr ""
 
-#: functions.php:164
+#: functions.php:165
 msgid "Unsaved changes"
 msgstr ""
 
-#: functions.php:165
+#: functions.php:166
 msgid "Draft saved automatically"
 msgstr ""
 
-#: functions.php:166
+#: functions.php:167
 msgid "Are you sure you want to reset all settings to default? This action cannot be undone."
 msgstr ""
 
-#: functions.php:167
+#: functions.php:168
 msgid "Resetting..."
 msgstr ""
 
-#: functions.php:168
+#: functions.php:169
 msgid "Settings reset successfully!"
 msgstr ""
 
-#: functions.php:169
+#: functions.php:170
 msgid "Error while resetting settings."
 msgstr ""
 
-#: functions.php:170
+#: functions.php:171
 msgid "Connection error during reset."
 msgstr ""
 
-#: functions.php:172
+#: functions.php:173
 msgid "Welcome to the Samira Theme control panel! Start customizing your settings."
 msgstr ""
 
-#: functions.php:184
+#: functions.php:185
 msgid "Footer Widget Area"
 msgstr ""
 
-#: functions.php:186
+#: functions.php:187
 msgid "Widget area in the footer"
 msgstr ""
 
-#: functions.php:194
+#: functions.php:195
 msgid "Blog Sidebar"
 msgstr ""
 
-#: functions.php:196
+#: functions.php:197
 msgid "Sidebar for blog posts"
 msgstr ""
 
-#: functions.php:212
-#: functions.php:214
+#: functions.php:213
+#: functions.php:215
 msgid "Portfolio"
 msgstr ""
 
-#: functions.php:213
+#: functions.php:214
 msgid "Work"
 msgstr ""
 
-#: functions.php:215
+#: functions.php:216
 msgid "Add Work"
 msgstr ""
 
-#: functions.php:216
+#: functions.php:217
 msgid "Add New Work"
 msgstr ""
 
-#: functions.php:217
+#: functions.php:218
 msgid "Edit Work"
 msgstr ""
 
-#: functions.php:218
+#: functions.php:219
 msgid "New Work"
 msgstr ""
 
-#: functions.php:219
+#: functions.php:220
 msgid "View Work"
 msgstr ""
 
-#: functions.php:220
+#: functions.php:221
 msgid "Search Works"
 msgstr ""
 
-#: functions.php:221
+#: functions.php:222
 msgid "No works found"
 msgstr ""
 
-#: functions.php:222
+#: functions.php:223
 msgid "No works in trash"
 msgstr ""
 
-#: functions.php:239
+#: functions.php:240
 #: index.php:91
 #: index.php:127
 msgid "Book"
 msgstr ""
 
-#: functions.php:240
+#: functions.php:241
 #: index.php:71
 msgid "My Books"
 msgstr ""
 
-#: functions.php:241
+#: functions.php:242
 msgid "Add Book"
 msgstr ""
 
-#: functions.php:242
+#: functions.php:243
 msgid "Add New Book"
 msgstr ""
 
-#: functions.php:243
+#: functions.php:244
 msgid "Edit Book"
 msgstr ""
 
-#: functions.php:386
+#: functions.php:387
 msgid "You do not have permission to upload SVG files."
 msgstr ""
 
@@ -688,32 +790,32 @@ msgstr ""
 msgid "Skip to content"
 msgstr ""
 
-#: header.php:47
+#: header.php:46
 msgid "Menu"
 msgstr ""
 
-#: header.php:69
+#: header.php:68
 msgid "Toggle dark mode"
 msgstr ""
 
-#: header.php:75
-#: header.php:91
+#: header.php:74
+#: header.php:89
 msgid "Contact"
 msgstr ""
 
-#: header.php:86
+#: header.php:84
 msgid "Home"
 msgstr ""
 
-#: header.php:87
+#: header.php:85
 msgid "About"
 msgstr ""
 
-#: header.php:89
+#: header.php:87
 msgid "Art"
 msgstr ""
 
-#: header.php:90
+#: header.php:88
 msgid "Blog"
 msgstr ""
 
@@ -722,32 +824,28 @@ msgid "Samira Quick Settings"
 msgstr ""
 
 #: inc/customizer.php:22
-msgid "Impostazioni rapide per il tema Samira"
+msgid "Quick settings for the Samira Theme"
 msgstr ""
 
 #: inc/customizer.php:28
-msgid "Colori"
-msgstr ""
-
-#: inc/customizer.php:41
-msgid "Colore Accento"
+msgid "Colors"
 msgstr ""
 
 #: inc/customizer.php:47
-msgid "Tipografia"
+msgid "Typography"
 msgstr ""
 
 #: inc/customizer.php:54
-msgid "Impostazioni Complete"
+msgid "Full Settings"
 msgstr ""
 
 #: inc/customizer.php:57
 #, php-format
-msgid "Per impostazioni avanzate, vai al %s"
+msgid "For advanced settings, go to %s"
 msgstr ""
 
 #: inc/customizer.php:58
-msgid "Pannello Samira Theme"
+msgid "Samira Theme Panel"
 msgstr ""
 
 #: inc/newsletter-integration.php:20
@@ -829,23 +927,13 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: inc/theme-options.php:37
-#: inc/theme-options.php:85
-#: index.php:19
-msgid "Samira Mahmoodi"
-msgstr ""
-
-#: inc/theme-options.php:38
-#: index.php:22
-msgid "Writing, Art, Rebirth"
+#: inc/newsletter-integration.php:434
+#: inc/newsletter-integration.php:456
+msgid "Access denied"
 msgstr ""
 
 #: inc/theme-options.php:43
 msgid "Samira Mahmoodi began writing shortly after graduating from college. In 2016, she received a Bachelor of Science in Nursing. Unable to suppress her despair at that time, journaling her feelings led her to rediscover her love for art and literature. She buried this integral part of herself after convincing her 14-year-old self she would be unsuccessful doing what she loved. In 2019, she released her first book, \"To Water Her Garden: A journey of self-discovery\". It was in this space that she unveiled the reasons behind her sadness, and where she also discovered her greatest power: herself."
-msgstr ""
-
-#: inc/theme-options.php:49
-msgid "To Water Her Garden: A journey of self-discovery"
 msgstr ""
 
 #: inc/theme-options.php:51
@@ -863,20 +951,6 @@ msgstr ""
 msgid "Art has spoken to me and understood me better than anyone else. It has always been my safe haven for self-expression. Creating my art empowers me beyond explanation."
 msgstr ""
 
-#: inc/theme-options.php:65
-#: index.php:205
-msgid "Stay Connected"
-msgstr ""
-
-#: inc/theme-options.php:66
-#: index.php:207
-msgid "Subscribe to receive my thoughts, updates on current and future releases."
-msgstr ""
-
-#: inc/theme-options.php:84
-msgid "Writer and artist. Art is my safe haven for self-expression."
-msgstr ""
-
 #: inc/theme-options.php:153
 msgid "Invalid color format"
 msgstr ""
@@ -885,27 +959,27 @@ msgstr ""
 msgid "Invalid newsletter provider"
 msgstr ""
 
-#: inc/theme-options.php:179
+#: inc/theme-options.php:193
 msgid "Invalid options format"
 msgstr ""
 
-#: inc/theme-options.php:267
+#: inc/theme-options.php:281
 msgid "Instagram"
 msgstr ""
 
-#: inc/theme-options.php:268
+#: inc/theme-options.php:282
 msgid "Goodreads"
 msgstr ""
 
-#: inc/theme-options.php:269
+#: inc/theme-options.php:283
 msgid "LinkedIn"
 msgstr ""
 
-#: inc/theme-options.php:270
+#: inc/theme-options.php:284
 msgid "Twitter"
 msgstr ""
 
-#: inc/theme-options.php:271
+#: inc/theme-options.php:285
 msgid "Facebook"
 msgstr ""
 

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Samira Mahmoodi Theme
-Description: Tema WordPress moderno e minimal per scrittori e artisti. Include dark mode, newsletter integration, e pannello di controllo personalizzato.
+Description: Modern and minimal WordPress theme for writers and artists. Includes dark mode, newsletter integration, and a custom control panel.
 Version: 1.0.0
 Author: Custom Theme Development
 Author URI: https://samira-theme.com
@@ -909,7 +909,7 @@ body.dark-mode .footer {
 }
 
 
-/* Footer Fix - Classi corrette per footer.php */
+/* Footer Fix - Correct classes for footer.php */
 .footer {
     background-color: var(--color-text);
     color: var(--color-background);


### PR DESCRIPTION
## Summary
- translate Italian strings to English across templates and admin screens
- wrap option defaults with translation helpers using `samira-theme` text domain
- regenerate `samira-theme.pot` translation template

## Testing
- `php wp-cli.phar i18n make-pot . languages/samira-theme.pot --allow-root`

------
https://chatgpt.com/codex/tasks/task_e_6895bd8889c0833387a3bbbc4f9616bd