### PR TITLE
feat(i18n): localize script messages

### DIFF
--- a/admin/admin-script.js
+++ b/admin/admin-script.js
@@ -8,7 +8,7 @@
 jQuery(document).ready(function($) {
     'use strict';
 
-    console.log('Samira Theme Admin loaded');
+    console.log(samira_admin.strings.admin_loaded);
 
     // Initialize all admin functionality
     initImageUpload();
@@ -47,7 +47,7 @@ jQuery(document).ready(function($) {
                 const attachment = mediaUploader.state().get('selection').first().toJSON();
 
                 $input.val(attachment.url);
-                $preview.html('<img src="' + attachment.url + '" alt="Selected Image" style="max-width: 200px; height: auto;" />');
+                $preview.html('<img src="' + attachment.url + '" alt="' + samira_admin.strings.selected_image_alt + '" style="max-width: 200px; height: auto;" />');
 
                 // Show success message
                 showNotification(samira_admin.strings.image_uploaded, 'success');
@@ -231,7 +231,7 @@ jQuery(document).ready(function($) {
                     showNotification(samira_admin.strings.draft_saved, 'info', 3000);
                 },
                 error: function() {
-                    console.warn('Auto-save failed');
+                    console.warn(samira_admin.strings.autosave_failed);
                 }
             });
         }

--- a/functions.php
+++ b/functions.php
@@ -102,6 +102,7 @@ function samira_theme_scripts() {
                 'dark_mode_activated'  => esc_html__( 'Dark mode activated', 'samira-theme' ),
                 'activate_light_mode'  => esc_html__( 'Activate light mode', 'samira-theme' ),
                 'activate_dark_mode'   => esc_html__( 'Activate dark mode', 'samira-theme' ),
+                'toggle_not_found'     => esc_html__( 'Dark mode toggle not found', 'samira-theme' ),
             ),
         )
     );
@@ -118,6 +119,8 @@ function samira_theme_scripts() {
             'email_invalid'   => esc_html__( 'Invalid email', 'samira-theme' ),
             'name'            => esc_html__( 'Name', 'samira-theme' ),
             'scroll_to_top'   => esc_html__( 'Scroll to top', 'samira-theme' ),
+            'theme_initialized' => esc_html__( 'Samira Theme initialized', 'samira-theme' ),
+            'ajax_error'      => esc_html__( 'AJAX Error:', 'samira-theme' ),
         )
     ));
     
@@ -171,6 +174,9 @@ function samira_admin_scripts($hook) {
                 'connection_error' => esc_html__( 'Connection error during reset.', 'samira-theme' ),
                 'reset_button'     => esc_html__( 'Reset to Default Settings', 'samira-theme' ),
                 'welcome_message'  => esc_html__( 'Welcome to the Samira Theme control panel! Start customizing your settings.', 'samira-theme' ),
+                'admin_loaded'     => esc_html__( 'Samira Theme Admin loaded', 'samira-theme' ),
+                'selected_image_alt' => esc_html__( 'Selected Image', 'samira-theme' ),
+                'autosave_failed'  => esc_html__( 'Auto-save failed', 'samira-theme' ),
             ),
         ));
     }

--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -18,7 +18,7 @@
         const body = document.body;
 
         if (!toggle) {
-            console.warn('Dark mode toggle not found');
+            console.warn(samira_dark_mode.strings.toggle_not_found);
             return;
         }
 

--- a/js/main.js
+++ b/js/main.js
@@ -15,7 +15,7 @@
 
     // Initialize all theme functionality
     function initTheme() {
-        console.log('Samira Theme initialized');
+        console.log(samira_ajax.strings.theme_initialized);
 
         initSmoothScroll();
         initScrollAnimations();
@@ -342,7 +342,7 @@
     // Handle form errors gracefully
     $(document).on('ajaxError', function(event, xhr, settings, error) {
         if (settings.url === samira_ajax.ajax_url) {
-            console.error('AJAX Error:', error);
+            console.error(samira_ajax.strings.ajax_error, error);
         }
     });
 

--- a/languages/samira-theme.pot
+++ b/languages/samira-theme.pot
@@ -1059,3 +1059,27 @@ msgstr ""
 #: index.php:313
 msgid "Sorry, no content matched your request. Please try searching for something else."
 msgstr ""
+
+#: js/main.js
+msgid "Samira Theme initialized"
+msgstr ""
+
+#: js/main.js
+msgid "AJAX Error:"
+msgstr ""
+
+#: js/dark-mode.js
+msgid "Dark mode toggle not found"
+msgstr ""
+
+#: admin/admin-script.js
+msgid "Samira Theme Admin loaded"
+msgstr ""
+
+#: admin/admin-script.js
+msgid "Selected Image"
+msgstr ""
+
+#: admin/admin-script.js
+msgid "Auto-save failed"
+msgstr ""


### PR DESCRIPTION
## Summary
- localize dark mode toggle message
- expose frontend and admin script strings for localization
- update translation template with new strings

## Testing
- `php -l functions.php`
- `node --check js/main.js`
- `node --check js/dark-mode.js`
- `node --check admin/admin-script.js`


------
https://chatgpt.com/codex/tasks/task_e_6895c1ea4be883339a75bf1bddca1370