### PR TITLE
feat(i18n): add translation support and document WPML pot file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Un tema WordPress moderno, elegante e completamente personalizzabile, progettato
 - **⚡ Performance Ottimizzate** - Lazy loading, CSS/JS minificati, caching-ready
 - **♿ Accessibilità WCAG** - Navigazione da tastiera, screen reader friendly
 - **🎨 Personalizzazione Avanzata** - Colori, tipografia, layout modificabili
+- **🌐 Multilingua Pronto** - File `.pot` per WPML/Polylang in `languages/`
 
 ### 🚀 Demo dal Vivo
 
@@ -31,6 +32,16 @@ Visualizza il tema in azione: [Demo Samira Theme](https://samira-theme-demo.com)
 2. **WordPress Admin** → Aspetto → Temi → Aggiungi Nuovo → Carica Tema
 3. **Attiva il tema** "Samira Theme" 
 4. **Configura** tramite il pannello "Samira Theme" nel menu admin
+
+### 🌐 Traduzioni e WPML
+
+Il tema è predisposto per la localizzazione. Il file sorgente delle stringhe si trova in `languages/samira-theme.pot` ed è compatibile con plugin come **WPML** e **Polylang**.
+
+Per rigenerare il file `.pot` è possibile utilizzare WP-CLI:
+
+```bash
+wp i18n make-pot . languages/samira-theme.pot
+```
 
 ### 🛠️ Configurazione
 

--- a/functions.php
+++ b/functions.php
@@ -20,8 +20,8 @@ define('SAMIRA_THEME_URI', get_template_directory_uri());
  * Theme setup
  */
 function samira_theme_setup() {
-    // Load theme text domain
-    load_theme_textdomain('samira-theme', get_template_directory() . '/languages');
+    // Load translations for theme
+    load_theme_textdomain('samira-theme', get_template_directory().'/languages');
 
     // Theme feature support
     add_theme_support('title-tag');

--- a/languages/samira-theme.pot
+++ b/languages/samira-theme.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-08T09:11:37+00:00\n"
+"POT-Creation-Date: 2025-08-08T09:37:11+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: samira-theme\n"
@@ -131,7 +131,7 @@ msgid "View Statistics"
 msgstr ""
 
 #: admin/theme-admin.php:158
-#: functions.php:172
+#: functions.php:175
 msgid "Reset to Default Settings"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgid "Portfolio Items"
 msgstr ""
 
 #: admin/theme-admin.php:872
-#: functions.php:239
+#: functions.php:245
 msgid "Books"
 msgstr ""
 
@@ -612,177 +612,201 @@ msgstr ""
 msgid "Activate dark mode"
 msgstr ""
 
-#: functions.php:114
-msgid "Loading..."
+#: functions.php:105
+msgid "Dark mode toggle not found"
 msgstr ""
 
 #: functions.php:115
-msgid "Operation completed!"
+msgid "Loading..."
 msgstr ""
 
 #: functions.php:116
-msgid "Error during the operation"
+msgid "Operation completed!"
 msgstr ""
 
 #: functions.php:117
-#: functions.php:160
-msgid "Required field"
+msgid "Error during the operation"
 msgstr ""
 
 #: functions.php:118
-#: functions.php:161
-msgid "Invalid email"
+#: functions.php:163
+msgid "Required field"
 msgstr ""
 
 #: functions.php:119
-msgid "Name"
+#: functions.php:164
+msgid "Invalid email"
 msgstr ""
 
 #: functions.php:120
+msgid "Name"
+msgstr ""
+
+#: functions.php:121
 msgid "Scroll to top"
 msgstr ""
 
-#: functions.php:156
-msgid "Select Image"
+#: functions.php:122
+msgid "Samira Theme initialized"
 msgstr ""
 
-#: functions.php:157
-msgid "Use this image"
-msgstr ""
-
-#: functions.php:158
-msgid "Image uploaded successfully!"
+#: functions.php:123
+msgid "AJAX Error:"
 msgstr ""
 
 #: functions.php:159
-msgid "Image removed"
+msgid "Select Image"
+msgstr ""
+
+#: functions.php:160
+msgid "Use this image"
+msgstr ""
+
+#: functions.php:161
+msgid "Image uploaded successfully!"
 msgstr ""
 
 #: functions.php:162
-msgid "Invalid URL"
-msgstr ""
-
-#: functions.php:163
-msgid "Please correct the errors in the form before saving"
-msgstr ""
-
-#: functions.php:164
-msgid "Saving..."
+msgid "Image removed"
 msgstr ""
 
 #: functions.php:165
-msgid "Unsaved changes"
+msgid "Invalid URL"
 msgstr ""
 
 #: functions.php:166
-msgid "Draft saved automatically"
+msgid "Please correct the errors in the form before saving"
 msgstr ""
 
 #: functions.php:167
-msgid "Are you sure you want to reset all settings to default? This action cannot be undone."
+msgid "Saving..."
 msgstr ""
 
 #: functions.php:168
-msgid "Resetting..."
+msgid "Unsaved changes"
 msgstr ""
 
 #: functions.php:169
-msgid "Settings reset successfully!"
+msgid "Draft saved automatically"
 msgstr ""
 
 #: functions.php:170
-msgid "Error while resetting settings."
+msgid "Are you sure you want to reset all settings to default? This action cannot be undone."
 msgstr ""
 
 #: functions.php:171
-msgid "Connection error during reset."
+msgid "Resetting..."
+msgstr ""
+
+#: functions.php:172
+msgid "Settings reset successfully!"
 msgstr ""
 
 #: functions.php:173
+msgid "Error while resetting settings."
+msgstr ""
+
+#: functions.php:174
+msgid "Connection error during reset."
+msgstr ""
+
+#: functions.php:176
 msgid "Welcome to the Samira Theme control panel! Start customizing your settings."
 msgstr ""
 
-#: functions.php:185
+#: functions.php:177
+msgid "Samira Theme Admin loaded"
+msgstr ""
+
+#: functions.php:178
+msgid "Selected Image"
+msgstr ""
+
+#: functions.php:179
+msgid "Auto-save failed"
+msgstr ""
+
+#: functions.php:191
 msgid "Footer Widget Area"
 msgstr ""
 
-#: functions.php:187
+#: functions.php:193
 msgid "Widget area in the footer"
 msgstr ""
 
-#: functions.php:195
+#: functions.php:201
 msgid "Blog Sidebar"
 msgstr ""
 
-#: functions.php:197
+#: functions.php:203
 msgid "Sidebar for blog posts"
 msgstr ""
 
-#: functions.php:213
-#: functions.php:215
+#: functions.php:219
+#: functions.php:221
 msgid "Portfolio"
 msgstr ""
 
-#: functions.php:214
+#: functions.php:220
 msgid "Work"
 msgstr ""
 
-#: functions.php:216
+#: functions.php:222
 msgid "Add Work"
 msgstr ""
 
-#: functions.php:217
+#: functions.php:223
 msgid "Add New Work"
 msgstr ""
 
-#: functions.php:218
+#: functions.php:224
 msgid "Edit Work"
 msgstr ""
 
-#: functions.php:219
+#: functions.php:225
 msgid "New Work"
 msgstr ""
 
-#: functions.php:220
+#: functions.php:226
 msgid "View Work"
 msgstr ""
 
-#: functions.php:221
+#: functions.php:227
 msgid "Search Works"
 msgstr ""
 
-#: functions.php:222
+#: functions.php:228
 msgid "No works found"
 msgstr ""
 
-#: functions.php:223
+#: functions.php:229
 msgid "No works in trash"
 msgstr ""
 
-#: functions.php:240
+#: functions.php:246
 #: index.php:91
 #: index.php:127
 msgid "Book"
 msgstr ""
 
-#: functions.php:241
+#: functions.php:247
 #: index.php:71
 msgid "My Books"
 msgstr ""
 
-#: functions.php:242
+#: functions.php:248
 msgid "Add Book"
 msgstr ""
 
-#: functions.php:243
+#: functions.php:249
 msgid "Add New Book"
 msgstr ""
 
-#: functions.php:244
+#: functions.php:250
 msgid "Edit Book"
 msgstr ""
 
-#: functions.php:387
+#: functions.php:393
 msgid "You do not have permission to upload SVG files."
 msgstr ""
 
@@ -1058,28 +1082,4 @@ msgstr ""
 
 #: index.php:313
 msgid "Sorry, no content matched your request. Please try searching for something else."
-msgstr ""
-
-#: js/main.js
-msgid "Samira Theme initialized"
-msgstr ""
-
-#: js/main.js
-msgid "AJAX Error:"
-msgstr ""
-
-#: js/dark-mode.js
-msgid "Dark mode toggle not found"
-msgstr ""
-
-#: admin/admin-script.js
-msgid "Samira Theme Admin loaded"
-msgstr ""
-
-#: admin/admin-script.js
-msgid "Selected Image"
-msgstr ""
-
-#: admin/admin-script.js
-msgid "Auto-save failed"
 msgstr ""


### PR DESCRIPTION
## Summary
- load textdomain from languages directory for WPML compatibility
- document `.pot` generation and translation usage in README
- regenerate `samira-theme.pot` with WP-CLI

## Testing
- `php wp-cli.phar i18n make-pot . languages/samira-theme.pot --allow-root`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_6895c4f1be488333acddc8b6c3ff63a6