### PR TITLE
fix(localization): translate AJAX messages and use localized JS notifications

### DIFF
--- a/admin/admin-script.js
+++ b/admin/admin-script.js
@@ -378,12 +378,12 @@ jQuery(document).ready(function($) {
                 nonce: $('#samira_nonce').val()
             }, function(response) {
                 if (response.success) {
-                    showNotification(samira_admin.strings.reset_success, 'success');
+                    showNotification(response.data.message || samira_admin.strings.reset_success, 'success');
                     setTimeout(function() {
                         location.reload();
                     }, 2000);
                 } else {
-                    showNotification(samira_admin.strings.reset_error, 'error');
+                    showNotification(response.data.message || samira_admin.strings.reset_error, 'error');
                     $button.prop('disabled', false).text(samira_admin.strings.reset_button);
                 }
             }).fail(function() {

--- a/admin/theme-admin.php
+++ b/admin/theme-admin.php
@@ -1021,10 +1021,10 @@ function samira_import_export_page() {
  */
 function samira_reset_options_ajax() {
     if (!wp_verify_nonce($_POST['nonce'], 'samira_reset') || !current_user_can('manage_options')) {
-        wp_send_json_error();
+        wp_send_json_error(array('message' => __( 'Access denied', 'samira-theme' )));
     }
 
     samira_reset_options();
-    wp_send_json_success();
+    wp_send_json_success(array('message' => __( 'Settings reset successfully!', 'samira-theme' )));
 }
 add_action('wp_ajax_samira_reset_options', 'samira_reset_options_ajax');

--- a/js/main.js
+++ b/js/main.js
@@ -207,7 +207,7 @@
                     }
                 },
                 error: function(xhr, status, error) {
-                    console.error('Newsletter signup error:', error);
+                    console.error(samira_ajax.strings.ajax_error, error);
                     showMessage('error', samira_ajax.strings.error);
                 },
                 complete: function() {


### PR DESCRIPTION
## Summary
- Localize reset options AJAX handler messages
- Display server-provided messages in admin notifications
- Use shared AJAX error string in frontend console output

## Testing
- `php -l admin/theme-admin.php`
- `node --check admin/admin-script.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6895fac26c40833399de0ef4c67e727b