### PR TITLE
style: consolidate duplicate selectors

### DIFF
--- a/style.css
+++ b/style.css
@@ -118,16 +118,17 @@ a:hover {
 }
 
 /* Header */
-.header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-  background: var(--header-bg);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--color-border);
-}
+  .header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: var(--header-bg);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--color-border);
+    transition: var(--transition-base);
+  }
 
 .header.scrolled {
   background: var(--color-surface);
@@ -182,12 +183,8 @@ a:hover {
   gap: var(--spacing-sm);
 }
 
-.header,
 .dark-mode-toggle {
   transition: var(--transition-base);
-}
-
-.dark-mode-toggle {
   background: none;
   border: none;
   color: var(--color-text);
@@ -910,16 +907,6 @@ body.dark-mode .footer {
 
 
 /* Footer Fix - Correct classes for footer.php */
-.footer {
-    background-color: var(--color-text);
-    color: var(--color-background);
-    padding: var(--spacing-xl) 0 var(--spacing-md);
-}
-
-body.dark-mode .footer {
-    background-color: #0a0a0a;
-}
-
 .footer-content {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));


### PR DESCRIPTION
## Summary
- ensure dark mode script loads without jQuery
- consolidate duplicate selectors for `.dark-mode-toggle` and footer blocks

## Testing
- `npx stylelint style.css | tail -n 20`
- `/root/.local/share/mise/installs/php/8.3.24/.composer/vendor/bin/phpcs --standard=WordPress functions.php | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689602d81d5c8333ad3ff196630149f7