### PR TITLE
feat(writing): add book link URL options

### DIFF
--- a/admin/theme-admin.php
+++ b/admin/theme-admin.php
@@ -449,6 +449,46 @@ function samira_render_writing_tab() {
                     </div>
                 </td>
             </tr>
+            <tr>
+                <th scope="row">
+                    <label for="samira_book_link_amazon"><?php _e('Amazon Link', 'samira-theme'); ?></label>
+                </th>
+                <td>
+                    <input type="url" id="samira_book_link_amazon" name="samira_book_link_amazon"
+                           value="<?php echo esc_attr(get_option('samira_book_link_amazon', '')); ?>"
+                           class="large-text" />
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="samira_book_link_bam"><?php _e('Books-A-Million Link', 'samira-theme'); ?></label>
+                </th>
+                <td>
+                    <input type="url" id="samira_book_link_bam" name="samira_book_link_bam"
+                           value="<?php echo esc_attr(get_option('samira_book_link_bam', '')); ?>"
+                           class="large-text" />
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="samira_book_link_bookshop"><?php _e('Bookshop Link', 'samira-theme'); ?></label>
+                </th>
+                <td>
+                    <input type="url" id="samira_book_link_bookshop" name="samira_book_link_bookshop"
+                           value="<?php echo esc_attr(get_option('samira_book_link_bookshop', '')); ?>"
+                           class="large-text" />
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="samira_book_link_bn"><?php _e('Barnes &amp; Noble Link', 'samira-theme'); ?></label>
+                </th>
+                <td>
+                    <input type="url" id="samira_book_link_bn" name="samira_book_link_bn"
+                           value="<?php echo esc_attr(get_option('samira_book_link_bn', '')); ?>"
+                           class="large-text" />
+                </td>
+            </tr>
         </table>
     </div>
     <?php

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -53,6 +53,10 @@ function samira_get_default_options() {
             'samira-theme'
         ),
         'samira_book_cover'       => '',
+        'samira_book_link_amazon'  => '',
+        'samira_book_link_bam'     => '',
+        'samira_book_link_bookshop' => '',
+        'samira_book_link_bn'      => '',
 
         // Art Section
         'samira_art_title'        => __( 'My Art', 'samira-theme' ),
@@ -117,6 +121,10 @@ function samira_sanitize_option($value, $option_name) {
     switch ($option_name) {
         case 'samira_hero_image':
         case 'samira_book_cover':
+        case 'samira_book_link_amazon':
+        case 'samira_book_link_bam':
+        case 'samira_book_link_bookshop':
+        case 'samira_book_link_bn':
             return esc_url_raw($value);
 
         case 'samira_social_instagram':


### PR DESCRIPTION
## Summary
- add Amazon, Books-A-Million, Bookshop, and Barnes & Noble link settings
- sanitize and persist new book link options

## Testing
- `php -l inc/theme-options.php`
- `php -l admin/theme-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_6896069174748333b842178fa14e43e6