### PR TITLE
feat: add art type taxonomy and portfolio tabs

### DIFF
--- a/archive-portfolio.php
+++ b/archive-portfolio.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Portfolio archive template
+ *
+ * @package Samira_Theme
+ */
+get_header(); ?>
+
+<main class="main-content">
+    <section class="section portfolio-archive">
+        <div class="container">
+            <h1 class="section__title"><?php post_type_archive_title(); ?></h1>
+            <?php
+            $terms = get_terms(
+                array(
+                    'taxonomy'   => 'art_type',
+                    'hide_empty' => true,
+                )
+            );
+            ?>
+            <?php if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) : ?>
+                <div class="portfolio-tabs" data-current="all">
+                    <button class="portfolio-tab active" data-term="all"><?php echo esc_html__( 'All', 'samira-theme' ); ?></button>
+                    <?php foreach ( $terms as $term ) : ?>
+                        <button class="portfolio-tab" data-term="<?php echo esc_attr( $term->slug ); ?>"><?php echo esc_html( $term->name ); ?></button>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+            <div class="art__gallery portfolio-grid">
+                <?php
+                $portfolio_loop = new WP_Query(
+                    array(
+                        'post_type'      => 'portfolio',
+                        'posts_per_page' => -1,
+                    )
+                );
+                if ( $portfolio_loop->have_posts() ) :
+                    while ( $portfolio_loop->have_posts() ) :
+                        $portfolio_loop->the_post();
+                        $item_terms = get_the_terms( get_the_ID(), 'art_type' );
+                        $term_slugs = $item_terms ? wp_list_pluck( $item_terms, 'slug' ) : array();
+                        $data_terms = implode( ' ', $term_slugs );
+                        ?>
+                        <div class="art-item portfolio-item" data-terms="<?php echo esc_attr( $data_terms ); ?>">
+                            <?php if ( has_post_thumbnail() ) : ?>
+                                <?php the_post_thumbnail( 'medium_large', array( 'class' => 'art-item__image' ) ); ?>
+                            <?php endif; ?>
+                            <div class="art-item__content">
+                                <h3 class="art-item__title"><?php the_title(); ?></h3>
+                            </div>
+                        </div>
+                    <?php
+                    endwhile;
+                    wp_reset_postdata();
+                else :
+                    ?>
+                    <p><?php echo esc_html__( 'No works found', 'samira-theme' ); ?></p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </section>
+</main>
+
+<?php get_footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -235,6 +235,7 @@ function samira_custom_post_types() {
         'menu_icon' => 'dashicons-art',
         'supports' => array('title', 'editor', 'thumbnail', 'excerpt', 'custom-fields'),
         'has_archive' => true,
+        'taxonomies' => array('art_type'),
         'rewrite' => array('slug' => 'portfolio'),
         'show_in_rest' => true,
     ));
@@ -261,6 +262,32 @@ function samira_custom_post_types() {
     ));
 }
 add_action('init', 'samira_custom_post_types');
+
+/**
+ * Custom Taxonomies
+ */
+function samira_custom_taxonomies() {
+    register_taxonomy('art_type', array('portfolio'), array(
+        'labels' => array(
+            'name'          => __( 'Art Types', 'samira-theme' ),
+            'singular_name' => __( 'Art Type', 'samira-theme' ),
+            'search_items'  => __( 'Search Art Types', 'samira-theme' ),
+            'all_items'     => __( 'All Art Types', 'samira-theme' ),
+            'edit_item'     => __( 'Edit Art Type', 'samira-theme' ),
+            'update_item'   => __( 'Update Art Type', 'samira-theme' ),
+            'add_new_item'  => __( 'Add New Art Type', 'samira-theme' ),
+            'new_item_name' => __( 'New Art Type Name', 'samira-theme' ),
+            'menu_name'     => __( 'Art Types', 'samira-theme' ),
+        ),
+        'hierarchical'      => false,
+        'public'            => true,
+        'show_ui'           => true,
+        'show_admin_column' => true,
+        'show_in_rest'      => true,
+        'rewrite'           => array('slug' => 'art-type'),
+    ));
+}
+add_action('init', 'samira_custom_taxonomies');
 
 /**
  * Book purchase links meta box.

--- a/index.php
+++ b/index.php
@@ -224,6 +224,9 @@ get_header(); ?>
                             <?php endfor;
                         endif; ?>
                     </div>
+                    <div class="art__actions">
+                        <a href="<?php echo esc_url( get_post_type_archive_link('portfolio') ); ?>" class="btn btn--outline"><?php echo esc_html__( 'Show all', 'samira-theme' ); ?></a>
+                    </div>
                 </div>
             </div>
         </section>

--- a/js/main.js
+++ b/js/main.js
@@ -24,6 +24,7 @@
         initNewsletterForm();
         initScrollToTop();
         initLazyLoading();
+        initPortfolioTabs();
     }
 
     // Smooth scrolling for anchor links
@@ -285,6 +286,38 @@
                 imageObserver.observe(this);
             });
         }
+    }
+
+    // Portfolio tabs filtering
+    function initPortfolioTabs() {
+        const $container = $('.portfolio-tabs');
+        if (!$container.length) {
+            return;
+        }
+
+        const $tabs = $container.find('.portfolio-tab');
+        const $items = $('.portfolio-item');
+        const current = $container.data('current') || 'all';
+
+        $tabs.on('click', function() {
+            const term = $(this).data('term');
+            $tabs.removeClass('active');
+            $(this).addClass('active');
+
+            if (term === 'all') {
+                $items.show();
+            } else {
+                $items.hide().filter(function() {
+                    const terms = $(this).data('terms');
+                    if (!terms) {
+                        return false;
+                    }
+                    return terms.split(' ').includes(term);
+                }).show();
+            }
+        });
+
+        $container.find(`[data-term="${current}"]`).trigger('click');
     }
 
     // Update active navigation link

--- a/style.css
+++ b/style.css
@@ -559,6 +559,28 @@ a:hover {
   line-height: 1.6;
 }
 
+.portfolio-tabs {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-lg);
+}
+
+.portfolio-tab {
+  border: 2px solid var(--color-accent);
+  background: transparent;
+  color: var(--color-text);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  cursor: pointer;
+  transition: var(--transition-base);
+}
+
+.portfolio-tab.active,
+.portfolio-tab:hover {
+  background-color: var(--color-accent);
+  color: #fff;
+}
+
 /* Newsletter Section */
 .newsletter {
   text-align: center;

--- a/taxonomy-art_type.php
+++ b/taxonomy-art_type.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Art Type taxonomy template
+ *
+ * @package Samira_Theme
+ */
+get_header(); ?>
+
+<main class="main-content">
+    <section class="section portfolio-archive">
+        <div class="container">
+            <h1 class="section__title"><?php single_term_title(); ?></h1>
+            <?php
+            $current_term_obj = get_queried_object();
+            $current_slug     = $current_term_obj ? $current_term_obj->slug : 'all';
+            $terms            = get_terms(
+                array(
+                    'taxonomy'   => 'art_type',
+                    'hide_empty' => true,
+                )
+            );
+            ?>
+            <?php if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) : ?>
+                <div class="portfolio-tabs" data-current="<?php echo esc_attr( $current_slug ); ?>">
+                    <button class="portfolio-tab" data-term="all"><?php echo esc_html__( 'All', 'samira-theme' ); ?></button>
+                    <?php foreach ( $terms as $term ) : ?>
+                        <button class="portfolio-tab" data-term="<?php echo esc_attr( $term->slug ); ?>"><?php echo esc_html( $term->name ); ?></button>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+            <div class="art__gallery portfolio-grid">
+                <?php
+                $portfolio_loop = new WP_Query(
+                    array(
+                        'post_type'      => 'portfolio',
+                        'posts_per_page' => -1,
+                    )
+                );
+                if ( $portfolio_loop->have_posts() ) :
+                    while ( $portfolio_loop->have_posts() ) :
+                        $portfolio_loop->the_post();
+                        $item_terms = get_the_terms( get_the_ID(), 'art_type' );
+                        $term_slugs = $item_terms ? wp_list_pluck( $item_terms, 'slug' ) : array();
+                        $data_terms = implode( ' ', $term_slugs );
+                        ?>
+                        <div class="art-item portfolio-item" data-terms="<?php echo esc_attr( $data_terms ); ?>">
+                            <?php if ( has_post_thumbnail() ) : ?>
+                                <?php the_post_thumbnail( 'medium_large', array( 'class' => 'art-item__image' ) ); ?>
+                            <?php endif; ?>
+                            <div class="art-item__content">
+                                <h3 class="art-item__title"><?php the_title(); ?></h3>
+                            </div>
+                        </div>
+                    <?php
+                    endwhile;
+                    wp_reset_postdata();
+                else :
+                    ?>
+                    <p><?php echo esc_html__( 'No works found', 'samira-theme' ); ?></p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </section>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- register `art_type` taxonomy for portfolio entries
- add portfolio archive and taxonomy templates with tabbed filtering
- include button linking home art section to full archive

## Testing
- `php -l functions.php`
- `php -l index.php`
- `php -l archive-portfolio.php`
- `php -l taxonomy-art_type.php`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68961da8f4148333936793f188ea921c